### PR TITLE
PERF: Optimize TemplateModelLexicalParser.cs

### DIFF
--- a/Omtt.Parser/Lexical/TemplateModelLexicalParser.cs
+++ b/Omtt.Parser/Lexical/TemplateModelLexicalParser.cs
@@ -22,6 +22,12 @@ namespace Omtt.Parser.Lexical
             MarkupLiterals.SpaceSymbol, 
             MarkupLiterals.CloseTagSymbol};
 
+        private static readonly String[] CloseTagLiterals = new[]
+        {
+            MarkupLiterals.CloseTagSymbol,
+            MarkupLiterals.CloseExpression
+        };
+
         internal async Task<List<Lexem>> ParseAsync(Stream stream)
         {
             using (var streamReader = new StreamReader(stream))
@@ -37,7 +43,7 @@ namespace Omtt.Parser.Lexical
                 
             List<Lexem> result = new List<Lexem>();
 
-            ProcessContent(source, result, true, new String[0]);
+            ProcessContent(source, result, true, Array.Empty<String>());
 
             return result;
         }
@@ -65,7 +71,7 @@ namespace Omtt.Parser.Lexical
                     AddTextAndSymbol(source, result, MarkupLiterals.QuoteSymbol);
 
                 else if (!foundExitSymbol && symbol != MarkupLiterals.CloseSymbol && inTextMode)
-                    ProcessContent(source, result, false, new [] {MarkupLiterals.CloseTagSymbol, MarkupLiterals.CloseExpression});
+                    ProcessContent(source, result, false, CloseTagLiterals);
             }
         }
 


### PR DESCRIPTION
Hi @tihilv, I've tried to make some performance optimizations to this repo. Following are the benchmark results before and after the changes:

**Benchmarks before changes:**
|                         Method |         Mean |       Error |      StdDev |       Median |    Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|------------------------------- |-------------:|------------:|------------:|-------------:|---------:|--------:|--------:|----------:|
|             OmttExpressionTest |     4.652 us |   0.2471 us |   0.7009 us |     4.622 us |   3.1738 |       - |       - |      6 KB |
|          ScribanExpressionTest |    42.900 us |   0.8510 us |   0.8739 us |    42.942 us |  19.2261 |       - |       - |     39 KB |
|                   OmttListTest | 1,438.178 us |  55.8078 us | 159.2229 us | 1,403.076 us | 123.0469 | 78.1250 | 41.0156 |    332 KB |
|                ScribanListTest | 3,167.818 us |  61.9256 us |  54.8954 us | 3,150.143 us |  39.0625 | 39.0625 | 39.0625 |    185 KB |
| ScribanListWithPreparationTest | 4,984.819 us | 331.0180 us | 976.0141 us | 4,694.340 us | 109.3750 | 54.6875 | 42.9688 |    526 KB |
|                OmttParsingTest |     6.238 us |   0.3722 us |   1.0739 us |     5.923 us |   2.6855 |       - |       - |      6 KB |
|             ScribanParsingTest |    10.484 us |   0.2678 us |   0.7854 us |    10.354 us |   2.7161 |       - |       - |      6 KB |

**Benchmarks after changes:**
|                         Method |         Mean |      Error |     StdDev |    Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|------------------------------- |-------------:|-----------:|-----------:|---------:|--------:|--------:|----------:|
|             OmttExpressionTest |     3.550 us |  0.0598 us |  0.0531 us |   3.1738 |       - |       - |      6 KB |
|          ScribanExpressionTest |    41.669 us |  0.6590 us |  0.5841 us |  19.2261 |       - |       - |     39 KB |
|                   OmttListTest | 1,254.431 us | 11.8248 us |  9.8743 us | 123.0469 | 74.2188 | 41.0156 |    332 KB |
|                ScribanListTest | 3,152.950 us | 26.8623 us | 22.4312 us |  42.9688 | 42.9688 | 42.9688 |    185 KB |
| ScribanListWithPreparationTest | 3,446.562 us | 28.0295 us | 26.2188 us | 109.3750 | 54.6875 | 42.9688 |    526 KB |
|                OmttParsingTest |     4.612 us |  0.0718 us |  0.0672 us |   2.6398 |       - |       - |      5 KB |
|             ScribanParsingTest |     8.910 us |  0.1615 us |  0.1431 us |   2.7161 |       - |       - |      6 KB |

As you can see the allocations for OmttParsingTest have gone down. I've also made sure that all the unit tests pass following these changes as well. Could you please confirm whether or not you think my changes are valid?

Thank you!

